### PR TITLE
Fix "workflow.py" typo in 04-dependencies.md

### DIFF
--- a/04-dependencies.md
+++ b/04-dependencies.md
@@ -13,7 +13,7 @@ minutes: 0
 
 Our data files are a product not only of our text files but the
 script, `wordcount.py`, that processes the text files and creates the
-data files. We should add `workflow.py` as a dependency of each of our
+data files. We should add `wordcount.py` as a dependency of each of our
 data files also:
 
 ~~~ {.make}


### PR DESCRIPTION
`04-dependencies` references the file `workflow.py` but should reference `wordcount.py`. This pull request fixes the typo.