### PR TITLE
Added the use of the automatic variable $*

### DIFF
--- a/05-patterns.md
+++ b/05-patterns.md
@@ -8,7 +8,7 @@ minutes: 0
 > ## Learning Objectives {.objectives}
 >
 > * Write Make pattern rules.
-> * Use the Make wild-card `%` in targets and dependencies.
+> * Use the Make wild-card `%` in targets and dependencies and `$*` in actions.
 > * Avoid using the Make wild-card in rules.
 
 Our Makefile still has repeated content. The rules for each `.dat`
@@ -19,10 +19,10 @@ rule](reference.html#pattern-rule) which can be used to build any
 
 ~~~ {.make}
 %.dat : books/%.txt wordcount.py
-        python wordcount.py $< $@
+        python wordcount.py $< $*.dat
 ~~~
 
-`%` is a Make [wild-card](reference.html#wild-card).
+`%` is a Make [wild-card](reference.html#wild-card), and `$*` is a special variable which gets replaced by the stemwith which the rule matched.
 
 If we re-run Make,
 
@@ -42,7 +42,9 @@ python wordcount.py books/last.txt last.dat
 > ## Using Make wild-cards {.callout}
 >
 > The Make `%` wild-card can only be used in a target and in its
-> dependencies. It cannot be used in actions. 
+> dependencies. It cannot be used in actions. In actions, you may
+> however use `$*`, which will be replaced by the stem with which 
+> the rule matched.
 
 Our Makefile is now much shorter and cleaner:
 
@@ -52,7 +54,7 @@ Our Makefile is now much shorter and cleaner:
 dats : isles.dat abyss.dat last.dat
 
 %.dat : books/%.txt wordcount.py
-	python wordcount.py $< $@
+	python wordcount.py $< $*.dat
 
 # Generate archive file.
 analysis.tar.gz : *.dat wordcount.py

--- a/05-patterns.md
+++ b/05-patterns.md
@@ -8,7 +8,8 @@ minutes: 0
 > ## Learning Objectives {.objectives}
 >
 > * Write Make pattern rules.
-> * Use the Make wild-card `%` in targets and dependencies and `$*` in actions.
+> * Use the Make wild-card `%` in targets and dependencies.
+> * Use the Make special variable `$*` in actions.
 > * Avoid using the Make wild-card in rules.
 
 Our Makefile still has repeated content. The rules for each `.dat`
@@ -22,7 +23,7 @@ rule](reference.html#pattern-rule) which can be used to build any
         python wordcount.py $< $*.dat
 ~~~
 
-`%` is a Make [wild-card](reference.html#wild-card), and `$*` is a special variable which gets replaced by the stem with which the rule matched.
+`%` is a Make [wild-card](reference.html#wild-card). `$*` is a special variable which gets replaced by the stem with which the rule matched.
 
 If we re-run Make,
 

--- a/05-patterns.md
+++ b/05-patterns.md
@@ -22,7 +22,7 @@ rule](reference.html#pattern-rule) which can be used to build any
         python wordcount.py $< $*.dat
 ~~~
 
-`%` is a Make [wild-card](reference.html#wild-card), and `$*` is a special variable which gets replaced by the stemwith which the rule matched.
+`%` is a Make [wild-card](reference.html#wild-card), and `$*` is a special variable which gets replaced by the stem with which the rule matched.
 
 If we re-run Make,
 

--- a/07-functions.md
+++ b/07-functions.md
@@ -21,7 +21,7 @@ include config.mk
 dats : isles.dat abyss.dat last.dat
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $@
+	$(COUNT_EXE) $< $*.dat
 
 # Generate archive file.
 analysis.tar.gz : *.dat $(COUNT_SRC)
@@ -184,7 +184,7 @@ variables:
 dats : $(DAT_FILES)
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $@
+	$(COUNT_EXE) $< $*.dat
 
 # Generate archive file.
 analysis.tar.gz : $(DAT_FILES) $(COUNT_SRC)

--- a/code/samples/05-patterns/Makefile
+++ b/code/samples/05-patterns/Makefile
@@ -1,6 +1,6 @@
 # Count words.
 %.dat : books/%.txt wordcount.py
-	python wordcount.py $< $@
+	python wordcount.py $< $*.dat
 
 .PHONY : clean
 clean :

--- a/code/samples/06-variables-challenge/Makefile
+++ b/code/samples/06-variables-challenge/Makefile
@@ -3,7 +3,7 @@ COUNT_EXE=python $(COUNT_SRC)
 
 # Count words.
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $@
+	$(COUNT_EXE) $< $*.dat
 
 .PHONY : clean
 clean :

--- a/code/samples/06-variables/Makefile
+++ b/code/samples/06-variables/Makefile
@@ -2,7 +2,7 @@ include config.mk
 
 # Count words.
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $@
+	$(COUNT_EXE) $< $*.dat
 
 .PHONY : clean
 clean :

--- a/code/samples/07-functions/Makefile
+++ b/code/samples/07-functions/Makefile
@@ -5,7 +5,7 @@ DAT_FILES=$(patsubst books/%.txt, %.dat, $(TXT_FILES))
 
 # Count words.
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $@
+	$(COUNT_EXE) $< $*.dat
 
 .PHONY : clean
 clean :

--- a/code/samples/08-conclusion-challenge/Makefile
+++ b/code/samples/08-conclusion-challenge/Makefile
@@ -6,11 +6,11 @@ JPG_FILES=$(patsubst books/%.txt, %.jpg, $(TXT_FILES))
 
 # Count words.
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $@
+	$(COUNT_EXE) $< $*.dat
 
 # Plot word counts.
 %.jpg : %.dat $(PLOT_SRC)
-	$(PLOT_EXE) $< $@
+	$(PLOT_EXE) $*.dat $*.jpg
 
 .PHONY : clean
 clean :

--- a/reference.md
+++ b/reference.md
@@ -215,7 +215,8 @@ automatic variable
     [rule](#rule). [Make](#make)'s automatic variables include `$@`,
     which holds the rule's [target](#target), `$^`, which holds its
     [dependencies](#dependency), and, `$<`, which holds the first of
-    its dependencies. Automatic variables are typically used in
+    its dependencies, and `$*`, which holds the [stem](#stem) with which
+    the pattern was matched. Automatic variables are typically used in
     [pattern rules](#pattern-rule).
 
 build file
@@ -286,7 +287,12 @@ reference
 rule
 :   A specification of a [target](#target)'s
     [dependencies](#dependency) and what [actions](#action) need to be
-    executed to build or update the target.
+    executed to build or update the target. 
+
+stem
+:   The part of the target that was matched by the pattern rule. If
+    the target is `file.dat` and the target pattern was `%.dat`, then
+    the stem `$*` is `file`. 
 
 target
 :   A thing to be created or updated, for example a file. Targets can

--- a/solutions.md
+++ b/solutions.md
@@ -135,7 +135,7 @@ COUNT_EXE=python $(COUNT_SRC)
 dats : isles.dat abyss.dat last.dat
 
 %.dat : books/%.txt COUNT_SRC
-    $(COUNT_EXE) $< $@
+    $(COUNT_EXE) $< $*.dat
 
 # Generate archive file.
 analysis.tar.gz : *.dat COUNT_SRC
@@ -179,11 +179,11 @@ JPG_FILES=$(patsubst books/%.txt, %.jpg, $(TXT_FILES))
 
 # Count words.
 %.dat : books/%.txt $(COUNT_SRC)
-    $(COUNT_EXE) $< $@
+    $(COUNT_EXE) $< $*.dat
 
 # Plot word counts.
 %.jpg : %.dat $(PLOT_SRC)
-    $(PLOT_EXE) $< $@
+    $(PLOT_EXE) $*.dat $*.jpg
 
 .PHONY : clean
 clean :


### PR DESCRIPTION
To replace $@. In my opinion, it is more readable using $*.dat than $@. The additional information ".dat" makes it clear that this is the target that we intend to generate.