### PR TITLE
Changed isles.jpg to isles.pdf

### DIFF
--- a/01-intro.md
+++ b/01-intro.md
@@ -69,7 +69,7 @@ Close the window to exit the plot.
 `plotcount.py` can also save the plot as an image (e.g. a JPEG):
 
 ~~~ {.bash}
-$ python plotcount.py isles.dat isles.jpg
+$ python plotcount.py isles.dat isles.pdf
 ~~~
 
 Together these scripts implement a common workflow:

--- a/02-makefiles.md
+++ b/02-makefiles.md
@@ -46,11 +46,11 @@ by Make. Let us go through each line in turn:
 Our rule above describes how to build the target `isles.dat` using the
 action `python wordcount.py` and the dependency `books/isles.txt`.
 
-Let's first sure we start from scratch and delete the `.dat` and `.jpg`
+Let's first sure we start from scratch and delete the `.dat` and `.pdf`
 files we created:
 
 ~~~ {.bash}
-$ rm *.dat *.jpg
+$ rm *.dat *.pdf
 ~~~
 
 By default, Make looks for a Makefile, called `Makefile`, and we can


### PR DESCRIPTION
When I was working through the lesson (in Python 3) all the code worked when I used 2to3 to updated the scripts to Python 3 except plotcount.py threw an error if I used the .jpg extension, but .pdf and .png worked fine.