### PR TITLE
Clarify -f option

### DIFF
--- a/02-makefiles.md
+++ b/02-makefiles.md
@@ -91,10 +91,10 @@ The first 5 lines of `isles.dat` should look exactly like before.
 
 We don't have to call our Makefile `Makefile`. However, if we call it
 something else we need to tell Make where to find it. This we can do
-using `-f` flag. For example:
+using `-f` flag. For example, if our Makefile is named `MyOtherMakefile`:
 
 ~~~ {.bash}
-$ make -f Makefile
+$ make -f MyOtherMakefile
 ~~~
 
 As we have re-run our Makefile, Make now informs us that:

--- a/02-makefiles.md
+++ b/02-makefiles.md
@@ -97,7 +97,7 @@ using `-f` flag. For example, if our Makefile is named `MyOtherMakefile`:
 $ make -f MyOtherMakefile
 ~~~
 
-As we have re-run our Makefile, Make now informs us that:
+When we re-run our Makefile, Make now informs us that:
 
 ~~~ {.output}
 make: `isles.dat' is up to date.


### PR DESCRIPTION
I thought this might be a little confusing since the name of the Makefile wasn't changed when using the `-f` option, but now it's not an example that could be run. It's probably not instructive to rename the Makefile, or maybe it would be since then it wouldn't run with `make` and no arguments. 