### PR TITLE
Adding auto-generated IDs

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -243,6 +243,7 @@ Default targets:
 
 ## Glossary
 
+{:auto_ids}
 action
 :   The steps a [build manager](#build-manager) must take to create or
     update a file or other object.


### PR DESCRIPTION
The new version of Kramdown will add IDs to glossary entries (definition lists) if instructed to do so.