### PR TITLE
Remove unnecessary variable in 09/conclusion-challenge-2/Makefile

### DIFF
--- a/code/09-conclusion-challenge-2/Makefile
+++ b/code/09-conclusion-challenge-2/Makefile
@@ -14,7 +14,7 @@ $(ZIPF_ARCHIVE) : $(ZIPF_DIR)
 	tar -czf $@ $<
 
 $(ZIPF_DIR): Makefile results.txt \
-             $(DAT_FILES) $(PNG_FILES) $(RESULTS_TXT) \
+             $(DAT_FILES) $(PNG_FILES) \
              $(COUNT_SRC) $(PLOT_SRC) $(ZIPF_SRC)
 	mkdir -p $@
 	cp $^ $@


### PR DESCRIPTION
Remove unnecessary $(RESULTS_TXT) variable in code/09-conclusion-challenge-2/Makefile, line 17