### PR TITLE
Fix two issues with Challenge: `wordcount` as a Dependency of `results.txt`.

### DIFF
--- a/_episodes/04-dependencies.md
+++ b/_episodes/04-dependencies.md
@@ -216,12 +216,12 @@ downstream steps.
 
 We still have to add the `zipf-test.py` script as dependency to
 `results.txt`. Given the answer to the challenge above, we cannot use
-`$^` for the rule. Instead we can use  `$<` to refer to the first dependency
-i.e. *.dat :
+`$^` for the rule. Instead we can move `zipf-test.py` to be the
+first dependency and then use `$<` to refer to this:
 
 ~~~
-results.txt : *.dat zipf_test.py
-        python zipf_test.py $< > $@
+results.txt : zipf_test.py *.dat
+        python $< *.dat > $@
 ~~~
 {: .make}
 

--- a/_episodes/04-dependencies.md
+++ b/_episodes/04-dependencies.md
@@ -169,24 +169,24 @@ downstream steps.
 > {: .solution}
 {: .challenge}
 
-> ## `wordcount` as a Dependency of `results.txt`.
+> ## `zipf_test.py` as a Dependency of `results.txt`.
 >
-> What would happen if you actually added `wordcount.py` as dependency of `results.txt`, and why?
+> What would happen if you added `zipf_test.py` as dependency of `results.txt`, and why?
 >
 > > ## Solution
 > >
 > > If you change the rule for the `results.txt` file like this:
 > >
 > > ~~~
-> > results.txt : *.dat wordcount.py
+> > results.txt : *.dat zipf_test.py
 > >         python zipf_test.py $^ > $@
 > > ~~~
 > > {: .make}
 > >
-> > `wordcount.py` becomes a part of `$^`, thus the command becomes
+> > `zipf_test.py` becomes a part of `$^`, thus the command becomes
 > >
 > > ~~~
-> > python zipf_test.py abyss.dat isles.dat last.dat wordcount.py > results.txt
+> > python zipf_test.py abyss.dat isles.dat last.dat zipf_test.py > results.txt
 > > ~~~
 > > {: .bash}
 > >
@@ -201,11 +201,11 @@ downstream steps.
 > > You'll get
 > >
 > > ~~~
-> > python zipf_test.py abyss.dat isles.dat last.dat wordcount.py > results.txt
+> > python zipf_test.py abyss.dat isles.dat last.dat zipf_test.py > results.txt
 > > Traceback (most recent call last):
 > >   File "zipf_test.py", line 19, in <module>
 > >     counts = load_word_counts(input_file)
-> >   File "path/to/wordcount.py", line 39, in load_word_counts
+> >   File "path/to/zipf_test.py", line 39, in load_word_counts
 > >     counts.append((fields[0], int(fields[1]), float(fields[2])))
 > > IndexError: list index out of range
 > > make: *** [results.txt] Error 1

--- a/_episodes/05-patterns.md
+++ b/_episodes/05-patterns.md
@@ -63,8 +63,8 @@ Our Makefile is now much shorter and cleaner:
 
 ~~~
 # Generate summary table.
-results.txt : *.dat zipf_test.py
-	    python zipf_test.py $< > $@
+results.txt : zipf_test.py *.dat
+        python $< *.dat > $@
 
 # Count words.
 .PHONY : dats

--- a/_episodes/07-functions.md
+++ b/_episodes/07-functions.md
@@ -18,8 +18,8 @@ At this point, we have the following Makefile:
 include config.mk
 
 # Generate summary table.
-results.txt : *.dat $(ZIPF_SRC)
-        $(ZIPF_EXE) $< > $@
+results.txt : $(ZIPF_SRC) *.dat
+        $(ZIPF_EXE) *.dat > $@
 
 # Count words.
 .PHONY : dats

--- a/code/04-dependencies/Makefile
+++ b/code/04-dependencies/Makefile
@@ -1,6 +1,6 @@
 # Generate summary table.
-results.txt : *.dat zipf_test.py
-	python zipf_test.py $< > $@
+results.txt : zipf_test.py *.dat
+	python $< *.dat > $@
 
 # Count words.
 .PHONY : dats

--- a/code/05-patterns/Makefile
+++ b/code/05-patterns/Makefile
@@ -1,6 +1,6 @@
 # Generate summary table.
-results.txt : *.dat zipf_test.py
-	python zipf_test.py $< > $@
+results.txt : zipf_test.py *.dat
+	python $< *.dat > $@
 
 # Count words.
 .PHONY : dats

--- a/code/06-variables-challenge/Makefile
+++ b/code/06-variables-challenge/Makefile
@@ -4,8 +4,8 @@ ZIPF_SRC=zipf_test.py
 ZIPF_EXE=python $(ZIPF_SRC)
 
 # Generate summary table.
-results.txt : *.dat $(ZIPF_SRC)
-	$(ZIPF_EXE) $< > $@
+results.txt : $(ZIPF_SRC) *.dat
+	$(ZIPF_EXE) *.dat > $@
 
 # Count words.
 .PHONY : dats

--- a/code/06-variables/Makefile
+++ b/code/06-variables/Makefile
@@ -1,8 +1,8 @@
 include config.mk
 
 # Generate summary table.
-results.txt : *.dat $(ZIPF_SRC)
-	$(ZIPF_EXE) $< > $@
+results.txt : $(ZIPF_SRC) *.dat
+	$(ZIPF_EXE) *.dat > $@
 
 # Count words.
 .PHONY : dats


### PR DESCRIPTION
This pull request addresses two issues with Challenge: `wordcount` as a Dependency of `results.txt` (http://swcarpentry.github.io/make-novice/04-dependencies/):

1. The focus of the exercise should be on adding `zipf_test.py` as a depenedency of `results.txt`, not `wordcount.py`. The problem that students are expected to identify in the challenge remains unchanged.

2. When adding `zipf_test.py`, the lesson suggests replacing `$^` with `$<` i,e:

```
results.txt : *.dat zipf_test.py
        python zipf_test.py $< > $@
```
But this is a bug since it means that only the first `.dat` file will ever be added to `results.txt`. This can be seen by using `code/04-dependencies/Makefile`:
```
$ make dats
python wordcount.py books/isles.txt isles.dat
python wordcount.py books/abyss.txt abyss.dat
python wordcount.py books/last.txt last.dat
$ make results.txt
python zipf_test.py last.dat > results.txt
$ cat results.txt 
Book	First	Second	Ratio
last	12244	5566	2.20
```

The following rule works:

```
results.txt : zipf_test.py *.dat
	python $< *.dat > $@
```
```
$ make dats
python wordcount.py books/isles.txt isles.dat
python wordcount.py books/abyss.txt abyss.dat
python wordcount.py books/last.txt last.dat
$ make results.txt
python zipf_test.py *.dat > results.txt
$ cat results.txt 
Book	First	Second	Ratio
abyss	4044	2807	1.44
isles	3822	2460	1.55
last	12244	5566	2.20
```

This commit applies the fix to the lesson and all downstream lessons and example code.
