### PR TITLE
Cleaned use of wildcards

### DIFF
--- a/_episodes/07-functions.md
+++ b/_episodes/07-functions.md
@@ -26,7 +26,7 @@ results.txt : $(ZIPF_SRC) *.dat
 dats : isles.dat abyss.dat last.dat
 
 %.dat : books/%.txt $(COUNT_SRC)
-        $(COUNT_EXE) $< $*.dat
+        $(COUNT_EXE) $< $@
 
 .PHONY : clean
 clean :
@@ -160,7 +160,7 @@ We can also rewrite `results.txt`:
 
 ~~~
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-        $(ZIPF_EXE) $< > $@
+        $(ZIPF_EXE) $(DAT_FILES) > $@
 ~~~
 {: .make}
 
@@ -217,14 +217,14 @@ DAT_FILES=$(patsubst books/%.txt, %.dat, $(TXT_FILES))
 
 # Generate summary table.
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-	$(ZIPF_EXE) $< > $@
+	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 # Count words.
 .PHONY : dats
 dats : $(DAT_FILES)
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $*.dat
+	$(COUNT_EXE) $< $@
 
 .PHONY : clean
 clean :

--- a/_episodes/08-self-doc.md
+++ b/_episodes/08-self-doc.md
@@ -59,14 +59,14 @@ which `sed` can detect. Since Make uses `#` for comments, we can use
 ~~~
 ## results.txt : Generate Zipf summary table.
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-        $(ZIPF_EXE) $< > $@
+        $(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.
 .PHONY : dats
 dats : $(DAT_FILES)
 
 %.dat : books/%.txt $(COUNT_SRC)
-        $(COUNT_EXE) $< $*.dat
+        $(COUNT_EXE) $< $@
 
 ## clean       : Remove auto-generated files.
 .PHONY : clean

--- a/code/06-variables-challenge/Makefile
+++ b/code/06-variables-challenge/Makefile
@@ -12,7 +12,7 @@ results.txt : $(ZIPF_SRC) *.dat
 dats : isles.dat abyss.dat last.dat
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $*.dat
+	$(COUNT_EXE) $< $@
 
 .PHONY : clean
 clean :

--- a/code/06-variables/Makefile
+++ b/code/06-variables/Makefile
@@ -9,7 +9,7 @@ results.txt : $(ZIPF_SRC) *.dat
 dats : isles.dat abyss.dat last.dat
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $*.dat
+	$(COUNT_EXE) $< $@
 
 .PHONY : clean
 clean :

--- a/code/07-functions/Makefile
+++ b/code/07-functions/Makefile
@@ -5,14 +5,14 @@ DAT_FILES=$(patsubst books/%.txt, %.dat, $(TXT_FILES))
 
 # Generate summary table.
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-	$(ZIPF_EXE) $< > $@
+	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 # Count words.
 .PHONY : dats
 dats : $(DAT_FILES)
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $*.dat
+	$(COUNT_EXE) $< $@
 
 .PHONY : clean
 clean :

--- a/code/08-self-doc/Makefile
+++ b/code/08-self-doc/Makefile
@@ -5,14 +5,14 @@ DAT_FILES=$(patsubst books/%.txt, %.dat, $(TXT_FILES))
 
 ## results.txt : Generate Zipf summary table.
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-	$(ZIPF_EXE) $< > $@
+	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.
 .PHONY : dats
 dats : $(DAT_FILES)
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $*.dat
+	$(COUNT_EXE) $< $@
 
 ## clean       : Remove auto-generated files.
 .PHONY : clean

--- a/code/09-conclusion-challenge-1/Makefile
+++ b/code/09-conclusion-challenge-1/Makefile
@@ -10,21 +10,21 @@ all : results.txt $(PNG_FILES)
 
 ## results.txt : Generate Zipf summary table.
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-	$(ZIPF_EXE) $< > $@
+	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.
 .PHONY : dats
 dats : $(DAT_FILES)
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $*.dat
+	$(COUNT_EXE) $< $@
 
 ## pngs        : Plot word counts.
 .PHONY : pngs
 pngs : $(PNG_FILES)
 
 %.png : %.dat $(PLOT_SRC)
-	$(PLOT_EXE) $*.dat $*.png
+	$(PLOT_EXE) $*.dat $@
 
 ## clean       : Remove auto-generated files.
 .PHONY : clean

--- a/code/09-conclusion-challenge-2/Makefile
+++ b/code/09-conclusion-challenge-2/Makefile
@@ -21,21 +21,21 @@ $(ZIPF_DIR): Makefile results.txt \
 
 ## results.txt : Generate Zipf summary table.
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-	$(ZIPF_EXE) $< > $@
+	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.
 .PHONY : dats
 dats : $(DAT_FILES)
 
 %.dat : books/%.txt $(COUNT_SRC)
-	$(COUNT_EXE) $< $*.dat
+	$(COUNT_EXE) $< $@
 
 ## pngs        : Plot word counts.
 .PHONY : pngs
 pngs : $(PNG_FILES)
 
 %.png : %.dat $(PLOT_SRC)
-	$(PLOT_EXE) $*.dat $*.png
+	$(PLOT_EXE) $*.dat $@
 
 ## clean       : Remove auto-generated files.
 .PHONY : clean


### PR DESCRIPTION
Replaced $< with .dat in %.dat targets from episode 6 onwards.
Fixed bug in use of $< with  in results.txt targets, by replacing with $(DAT_FILES).
Fixes #92.
