### PR TITLE
Fixing minor typos

### DIFF
--- a/_episodes/04-dependencies.md
+++ b/_episodes/04-dependencies.md
@@ -216,10 +216,10 @@ downstream steps.
 > {: .solution}
 {: .challenge}
 
-We still have to add the `zipf-test.py` script as dependency to
+We still have to add the `zipf_test.py` script as dependency to
 `results.txt`. Given the answer to the challenge above, we cannot use
 `$^` in the rule.  
-We can however move `zipf-test.py` to be the
+We can however move `zipf_test.py` to be the
 first dependency and then use `$<` to refer to it. 
 In order to refer to the `.dat` files, we can just use `*.dat` for now (we will
 cover a better solution later on).

--- a/_episodes/09-conclusion.md
+++ b/_episodes/09-conclusion.md
@@ -36,7 +36,7 @@ papers.
 > target]({{ page.root }}/reference/#phony-target) called `all` as first target,
 > that will build what the Makefile has been written to build (e.g. in
 > our case, the `.png` files and the `results.txt` file). As others
-> may assume your Makefile confirms to convention and supports an
+> may assume your Makefile conforms to convention and supports an
 > `all` target, add an `all` target to your Makefile (Hint: this rule
 > has the `results.txt` file and the `.png` files as dependencies, but
 > no actions).  With that in place, instead of running `make


### PR DESCRIPTION
Episode-04 Changed dash in file name to underscore to match file names in code.  Episode 09: changed misspelling of conforms.

