### PR TITLE
convert space to tab

### DIFF
--- a/_episodes/02-makefiles.md
+++ b/_episodes/02-makefiles.md
@@ -22,7 +22,7 @@ Create a file, called `Makefile`, with the following content:
 ~~~
 # Count words.
 isles.dat : books/isles.txt
-        python wordcount.py books/isles.txt isles.dat
+	python wordcount.py books/isles.txt isles.dat
 ~~~
 {: .make}
 

--- a/_episodes/02-makefiles.md
+++ b/_episodes/02-makefiles.md
@@ -186,7 +186,7 @@ Let's add another rule to the end of `Makefile`:
 
 ~~~
 abyss.dat : books/abyss.txt
-        python wordcount.py books/abyss.txt abyss.dat
+	python wordcount.py books/abyss.txt abyss.dat
 ~~~
 {: .make}
 
@@ -262,7 +262,7 @@ delete auto-generated files, like our `.dat` files:
 
 ~~~
 clean :
-        rm -f *.dat
+	rm -f *.dat
 ~~~
 {: .make}
 
@@ -400,14 +400,14 @@ Our Makefile now looks like this:
 dats : isles.dat abyss.dat
 
 isles.dat : books/isles.txt
-        python wordcount.py books/isles.txt isles.dat
+	python wordcount.py books/isles.txt isles.dat
 
 abyss.dat : books/abyss.txt
-        python wordcount.py books/abyss.txt abyss.dat
+	python wordcount.py books/abyss.txt abyss.dat
 
 .PHONY : clean
 clean :
-        rm -f *.dat
+	rm -f *.dat
 ~~~
 {: .make}
 

--- a/_episodes/03-variables.md
+++ b/_episodes/03-variables.md
@@ -25,18 +25,18 @@ results.txt : isles.dat abyss.dat last.dat
 dats : isles.dat abyss.dat last.dat
 
 isles.dat : books/isles.txt
-        python wordcount.py books/isles.txt isles.dat
+	python wordcount.py books/isles.txt isles.dat
 
 abyss.dat : books/abyss.txt
-        python wordcount.py books/abyss.txt abyss.dat
+	python wordcount.py books/abyss.txt abyss.dat
 
 last.dat : books/last.txt
-        python wordcount.py books/last.txt last.dat
+	python wordcount.py books/last.txt last.dat
 
 .PHONY : clean
 clean :
-        rm -f *.dat
-        rm -f results.txt
+	rm -f *.dat
+	rm -f results.txt
 ~~~
 {: .make}
 
@@ -65,7 +65,7 @@ name of the results file name:
 
 ~~~
 results.txt : isles.dat abyss.dat last.dat
-        python zipf_test.py abyss.dat isles.dat last.dat > results.txt
+	python zipf_test.py abyss.dat isles.dat last.dat > results.txt
 ~~~
 {: .make}
 
@@ -74,7 +74,7 @@ with `$@`:
 
 ~~~
 results.txt : isles.dat abyss.dat last.dat
-        python zipf_test.py abyss.dat isles.dat last.dat > $@
+	python zipf_test.py abyss.dat isles.dat last.dat > $@
 ~~~
 {: .make}
 
@@ -86,7 +86,7 @@ We can replace the dependencies in the action with `$^`:
 
 ~~~
 results.txt : isles.dat abyss.dat last.dat
-        python zipf_test.py $^ > $@
+	python zipf_test.py $^ > $@
 ~~~
 {: .make}
 

--- a/_episodes/04-dependencies.md
+++ b/_episodes/04-dependencies.md
@@ -17,25 +17,25 @@ Our Makefile now looks like this:
 ~~~
 # Generate summary table.
 results.txt : isles.dat abyss.dat last.dat
-        python zipf_test.py $^ > $@
+	python zipf_test.py $^ > $@
 
 # Count words.
 .PHONY : dats
 dats : isles.dat abyss.dat last.dat
 
 isles.dat : books/isles.txt
-        python wordcount.py $< $@
+	python wordcount.py $< $@
 
 abyss.dat : books/abyss.txt
-        python wordcount.py $< $@
+	python wordcount.py $< $@
 
 last.dat : books/last.txt
-        python wordcount.py $< $@
+	python wordcount.py $< $@
 
 .PHONY : clean
 clean :
-        rm -f *.dat
-        rm -f results.txt
+	rm -f *.dat
+	rm -f results.txt
 ~~~
 {: .make}
 
@@ -62,13 +62,13 @@ data files also:
 
 ~~~
 isles.dat : books/isles.txt wordcount.py
-        python wordcount.py $< $@
+	python wordcount.py $< $@
 
 abyss.dat : books/abyss.txt wordcount.py
-        python wordcount.py $< $@
+	python wordcount.py $< $@
 
 last.dat : books/last.txt wordcount.py
-        python wordcount.py $< $@
+	python wordcount.py $< $@
 ~~~
 {: .make}
 
@@ -226,7 +226,7 @@ cover a better solution later on).
 
 ~~~
 results.txt : zipf_test.py isles.dat abyss.dat last.dat
-        python $< *.dat > $@
+	python $< *.dat > $@
 ~~~
 {: .make}
 

--- a/_episodes/05-patterns.md
+++ b/_episodes/05-patterns.md
@@ -19,7 +19,7 @@ rule]({{ page.root }}/reference/#pattern-rule) which can be used to build any
 
 ~~~
 %.dat : books/%.txt wordcount.py
-        python wordcount.py $< $*.dat
+	python wordcount.py $< $*.dat
 ~~~
 {: .make}
 
@@ -77,19 +77,19 @@ Our Makefile is now much shorter and cleaner:
 ~~~
 # Generate summary table.
 results.txt : zipf_test.py isles.dat abyss.dat last.dat
-        python $< *.dat > $@
+	python $< *.dat > $@
 
 # Count words.
 .PHONY : dats
 dats : isles.dat abyss.dat last.dat
 
 %.dat : books/%.txt wordcount.py
-      python wordcount.py $< $*.dat
+	python wordcount.py $< $*.dat
 
 .PHONY : clean
 clean :
-      rm -f *.dat
-      rm -f results.txt
+	rm -f *.dat
+	rm -f results.txt
 ~~~
 {: .make}
 

--- a/_episodes/07-functions.md
+++ b/_episodes/07-functions.md
@@ -103,8 +103,8 @@ We can extend `variables` to show the value of `DAT_FILES` too:
 ~~~
 .PHONY : variables
 variables:
-        @echo TXT_FILES: $(TXT_FILES)
-        @echo DAT_FILES: $(DAT_FILES)
+	@echo TXT_FILES: $(TXT_FILES)
+	@echo DAT_FILES: $(DAT_FILES)
 ~~~
 {: .make}
 
@@ -133,8 +133,8 @@ dats : $(DAT_FILES)
 
 .PHONY : clean
 clean :
-        rm -f $(DAT_FILES)
-        rm -f results.txt
+	rm -f $(DAT_FILES)
+	rm -f results.txt
 ~~~
 {: .make}
 
@@ -168,7 +168,7 @@ We can also rewrite `results.txt`:
 
 ~~~
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-        $(ZIPF_EXE) $(DAT_FILES) > $@
+	$(ZIPF_EXE) $(DAT_FILES) > $@
 ~~~
 {: .make}
 

--- a/_episodes/08-self-doc.md
+++ b/_episodes/08-self-doc.md
@@ -36,9 +36,9 @@ So, how would we implement this? We could write a rule like:
 ~~~
 .PHONY : help
 help :
-        @echo "results.txt : Generate Zipf summary table."
-        @echo "dats        : Count words in text files."
-        @echo "clean       : Remove auto-generated files."
+	@echo "results.txt : Generate Zipf summary table."
+	@echo "dats        : Count words in text files."
+	@echo "clean       : Remove auto-generated files."
 ~~~
 {: .make}
 
@@ -59,26 +59,26 @@ which `sed` can detect. Since Make uses `#` for comments, we can use
 ~~~
 ## results.txt : Generate Zipf summary table.
 results.txt : $(DAT_FILES) $(ZIPF_SRC)
-        $(ZIPF_EXE) $(DAT_FILES) > $@
+	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.
 .PHONY : dats
 dats : $(DAT_FILES)
 
 %.dat : books/%.txt $(COUNT_SRC)
-        $(COUNT_EXE) $< $@
+	$(COUNT_EXE) $< $@
 
 ## clean       : Remove auto-generated files.
 .PHONY : clean
 clean :
-        rm -f $(DAT_FILES)
-        rm -f results.txt
+	rm -f $(DAT_FILES)
+	rm -f results.txt
 
 ## variables   : Print variables.
 .PHONY : variables
 variables:
-        @echo TXT_FILES: $(TXT_FILES)
-        @echo DAT_FILES: $(DAT_FILES)
+	@echo TXT_FILES: $(TXT_FILES)
+	@echo DAT_FILES: $(DAT_FILES)
 ~~~
 {: .make}
 


### PR DESCRIPTION
The example Makefile in episode 2 uses spaces instead of tab. There is a not about this later on, but I think it makes sense to fix this in example as well. Also, this is part of instructor training checkout.