### PR TITLE
Change links '/reference/#...' to '/reference#...'

### DIFF
--- a/_episodes/02-makefiles.md
+++ b/_episodes/02-makefiles.md
@@ -26,22 +26,22 @@ isles.dat : books/isles.txt
 ~~~
 {: .make}
 
-This is a [build file]({{ page.root }}/reference/#build-file), which for
-Make is called a [Makefile]({{ page.root }}/reference/#makefile) - a file executed
+This is a [build file]({{ page.root }}/reference#build-file), which for
+Make is called a [Makefile]({{ page.root }}/reference#makefile) - a file executed
 by Make. Note how it resembles one of the lines from our shell script.
 
 Let us go through each line in turn:
 
 * `#` denotes a *comment*. Any text from `#` to the end of the line is
   ignored by Make.
-* `isles.dat` is a [target]({{ page.root }}/reference/#target), a file to be
+* `isles.dat` is a [target]({{ page.root }}/reference#target), a file to be
   created, or built.
-* `books/isles.txt` is a [dependency]({{ page.root }}/reference/#dependency), a
+* `books/isles.txt` is a [dependency]({{ page.root }}/reference#dependency), a
   file that is needed to build or update the target. Targets can have
   zero or more dependencies.
 * A colon, `:`, separates targets from dependencies.
 * `python wordcount.py books/isles.txt isles.dat` is an
-  [action]({{ page.root }}/reference/#action), a command to run to build or update
+  [action]({{ page.root }}/reference#action), a command to run to build or update
   the target using the dependencies. Targets can have zero or more
   actions. These actions form a recipe to build the target
   from its dependencies and can be considered to be
@@ -52,7 +52,7 @@ Let us go through each line in turn:
   your cursor from one side of the TAB to the other. It should jump
   four or more spaces.
 * Together, the target, dependencies, and actions form a
-  [rule]({{ page.root }}/reference/#rule).
+  [rule]({{ page.root }}/reference#rule).
 
 Our rule above describes how to build the target `isles.dat` using the
 action `python wordcount.py` and the dependency `books/isles.txt`.
@@ -173,7 +173,7 @@ been updated since the target, then the actions are re-run to update
 the target. Using this approach, Make knows to only rebuild the files
 that, either directly or indirectly, depend on the file that
 changed. This is called an [incremental
-build]({{ page.root }}/reference/#incremental-build).
+build]({{ page.root }}/reference#incremental-build).
 
 > ## Makefiles as Documentation
 >
@@ -206,7 +206,7 @@ make: `isles.dat' is up to date.
 
 Nothing happens because Make attempts to build the first target it
 finds in the Makefile, the [default
-target]({{ page.root }}/reference/#default-target), which is `isles.dat` which is
+target]({{ page.root }}/reference#default-target), which is `isles.dat` which is
 already up-to-date. We need to explicitly tell Make we want to build
 `abyss.dat`:
 
@@ -308,7 +308,7 @@ rule has no dependencies, assumes that `clean` has been built and is
 up-to-date and so does not execute the rule's actions. As we are using
 `clean` as a short-hand, we need to tell Make to always execute this
 rule if we run `make clean`, by telling Make that this is a
-[phony target]({{ page.root }}/reference/#phony-target), that it does not build
+[phony target]({{ page.root }}/reference#phony-target), that it does not build
 anything. This we do by marking the target as `.PHONY`:
 
 ~~~
@@ -334,7 +334,7 @@ rm -f *.dat
 
 We can add a similar command to create all the data files. We can put
 this at the top of our Makefile so that it is the [default
-target]({{ page.root }}/reference/#default-target), which is executed by default
+target]({{ page.root }}/reference#default-target), which is executed by default
 if no target is given to the `make` command:
 
 ~~~

--- a/_episodes/03-variables.md
+++ b/_episodes/03-variables.md
@@ -78,7 +78,7 @@ results.txt : isles.dat abyss.dat last.dat
 ~~~
 {: .make}
 
-`$@` is a Make [automatic variable]({{ page.root }}/reference/#automatic-variable)
+`$@` is a Make [automatic variable]({{ page.root }}/reference#automatic-variable)
 which means 'the target of the current rule'. When Make is run it will
 replace this variable with the target name.
 

--- a/_episodes/04-dependencies.md
+++ b/_episodes/04-dependencies.md
@@ -115,7 +115,7 @@ in this episode).
 >
 > `.txt` files are input files and have no dependencies. To make these
 > depend on `wordcount.py` would introduce a [false
-> dependency]({{ page.root }}/reference/#false-dependency).
+> dependency]({{ page.root }}/reference#false-dependency).
 {: .callout}
 
 Intuitively, we should also add `wordcount.py` as dependency for

--- a/_episodes/05-patterns.md
+++ b/_episodes/05-patterns.md
@@ -14,7 +14,7 @@ keypoints:
 Our Makefile still has repeated content. The rules for each `.dat`
 file are identical apart from the text and data file names. We can
 replace these rules with a single [pattern
-rule]({{ page.root }}/reference/#pattern-rule) which can be used to build any
+rule]({{ page.root }}/reference#pattern-rule) which can be used to build any
 `.dat` file from a `.txt` file in `books/`:
 
 ~~~
@@ -23,8 +23,8 @@ rule]({{ page.root }}/reference/#pattern-rule) which can be used to build any
 ~~~
 {: .make}
 
-`%` is a Make [wildcard]({{ page.root }}/reference/#wildcard).  `$*` is a special
-variable which gets replaced by the [stem]({{ page.root }}/reference/#stem) with
+`%` is a Make [wildcard]({{ page.root }}/reference#wildcard).  `$*` is a special
+variable which gets replaced by the [stem]({{ page.root }}/reference#stem) with
 which the rule matched.
 
 This rule can be interpreted as:

--- a/_episodes/06-variables.md
+++ b/_episodes/06-variables.md
@@ -16,8 +16,8 @@ Despite our efforts, our Makefile still has repeated content, namely
 the name of our script, `wordcount.py`. If we renamed our script we'd
 have to update our Makefile in multiple places.
 
-We can introduce a Make [variable]({{ page.root }}/reference/#variable) (called a
-[macro]({{ page.root }}/reference/#macro) in some versions of Make) to hold our
+We can introduce a Make [variable]({{ page.root }}/reference#variable) (called a
+[macro]({{ page.root }}/reference#macro) in some versions of Make) to hold our
 script name:
 
 ~~~
@@ -25,7 +25,7 @@ COUNT_SRC=wordcount.py
 ~~~
 {: .make}
 
-This is a variable [assignment]({{ page.root }}/reference/#assignment) -
+This is a variable [assignment]({{ page.root }}/reference#assignment) -
 `COUNT_SRC` is assigned the value `wordcount.py`.
 
 `wordcount.py` is our script and it is invoked by passing it to
@@ -38,7 +38,7 @@ COUNT_EXE=python $(COUNT_SRC)
 {: .make}
 
 `$(...)` tells Make to replace a variable with its value when Make
-is run. This is a variable [reference]({{ page.root }}/reference/#reference). At
+is run. This is a variable [reference]({{ page.root }}/reference#reference). At
 any place where we want to use the value of a variable we have to
 write it, or reference it, in this way.
 

--- a/_episodes/07-functions.md
+++ b/_episodes/07-functions.md
@@ -35,7 +35,7 @@ clean :
 ~~~
 {: .make}
 
-Make has many [functions]({{ page.root }}/reference/#function) which can be used to
+Make has many [functions]({{ page.root }}/reference#function) which can be used to
 write more complex rules. One example is `wildcard`. `wildcard` gets a
 list of files matching some pattern, which we can then save in a
 variable. So, for example, we can get a list of all our text files

--- a/_episodes/09-conclusion.md
+++ b/_episodes/09-conclusion.md
@@ -33,7 +33,7 @@ papers.
 >   `results.txt`).
 >
 > Finally, many Makefiles define a default [phony
-> target]({{ page.root }}/reference/#phony-target) called `all` as first target,
+> target]({{ page.root }}/reference#phony-target) called `all` as first target,
 > that will build what the Makefile has been written to build (e.g. in
 > our case, the `.png` files and the `results.txt` file). As others
 > may assume your Makefile conforms to convention and supports an


### PR DESCRIPTION
Updates all links to the reference page so that they no longer produce a "404: File not found" error when clicked