### PR TITLE
Un-reorder dependencies of results.txt

### DIFF
--- a/_episodes/07-functions.md
+++ b/_episodes/07-functions.md
@@ -167,7 +167,7 @@ python wordcount.py books/sierra.txt sierra.dat
 We can also rewrite `results.txt`: 
 
 ~~~
-results.txt : $(DAT_FILES) $(ZIPF_SRC)
+results.txt : $(ZIPF_SRC) $(DAT_FILES)
 	$(ZIPF_EXE) $(DAT_FILES) > $@
 ~~~
 {: .make}
@@ -219,7 +219,7 @@ TXT_FILES=$(wildcard books/*.txt)
 DAT_FILES=$(patsubst books/%.txt, %.dat, $(TXT_FILES))
 
 # Generate summary table.
-results.txt : $(DAT_FILES) $(ZIPF_SRC)
+results.txt : $(ZIPF_SRC) $(DAT_FILES) 
 	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 # Count words.

--- a/_episodes/08-self-doc.md
+++ b/_episodes/08-self-doc.md
@@ -58,7 +58,7 @@ which `sed` can detect. Since Make uses `#` for comments, we can use
 
 ~~~
 ## results.txt : Generate Zipf summary table.
-results.txt : $(DAT_FILES) $(ZIPF_SRC)
+results.txt : $(ZIPF_SRC) $(DAT_FILES)
 	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.

--- a/code/07-functions/Makefile
+++ b/code/07-functions/Makefile
@@ -4,7 +4,7 @@ TXT_FILES=$(wildcard books/*.txt)
 DAT_FILES=$(patsubst books/%.txt, %.dat, $(TXT_FILES))
 
 # Generate summary table.
-results.txt : $(DAT_FILES) $(ZIPF_SRC)
+results.txt : $(ZIPF_SRC) $(DAT_FILES)
 	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 # Count words.

--- a/code/08-self-doc/Makefile
+++ b/code/08-self-doc/Makefile
@@ -4,7 +4,7 @@ TXT_FILES=$(wildcard books/*.txt)
 DAT_FILES=$(patsubst books/%.txt, %.dat, $(TXT_FILES))
 
 ## results.txt : Generate Zipf summary table.
-results.txt : $(DAT_FILES) $(ZIPF_SRC)
+results.txt : $(ZIPF_SRC) $(DAT_FILES)
 	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.

--- a/code/09-conclusion-challenge-1/Makefile
+++ b/code/09-conclusion-challenge-1/Makefile
@@ -9,7 +9,7 @@ PNG_FILES=$(patsubst books/%.txt, %.png, $(TXT_FILES))
 all : results.txt $(PNG_FILES)
 
 ## results.txt : Generate Zipf summary table.
-results.txt : $(DAT_FILES) $(ZIPF_SRC)
+results.txt : $(ZIPF_SRC) $(DAT_FILES)
 	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.

--- a/code/09-conclusion-challenge-2/Makefile
+++ b/code/09-conclusion-challenge-2/Makefile
@@ -23,7 +23,7 @@ $(ZIPF_DIR): Makefile config.mk $(RESULTS_FILE) \
 	touch $@
 
 ## results.txt : Generate Zipf summary table.
-$(RESULTS_FILE) : $(DAT_FILES) $(ZIPF_SRC)
+$(RESULTS_FILE) : $(ZIPF_SRC) $(DAT_FILES)
 	$(ZIPF_EXE) $(DAT_FILES) > $@
 
 ## dats        : Count words in text files.


### PR DESCRIPTION
Fix #128.

Previous makefile has this rule:
results.txt : $(ZIPF_SRC) isles.dat abyss.dat last.dat

This then gets rewritten as
results.txt : $(DAT_FILES) $(ZIPF_SRC)

but there's no good reason to reorder the dependencies, so I'm
replacing the explicit dependencies with a variable in the same order:

results.txt : $(ZIPF_SRC) $(DAT_FILES)

My hope it that this makes the lesson easier to follow.