### PR TITLE
updated 'wordcount' to 'countwords' in `plotcounts.py`

### DIFF
--- a/code/plotcounts.py
+++ b/code/plotcounts.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import sys
 from collections import Sequence
 
-from wordcount import load_word_counts
+from countwords import load_word_counts
 
 
 def plot_word_counts(counts, limit=10):

--- a/code/testzipf.py
+++ b/code/testzipf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from wordcount import load_word_counts
+from countwords import load_word_counts
 import sys
 
 def top_two_word(counts):


### PR DESCRIPTION
I kept getting an error when running `python plotcounts.py isles.dat ascii` in the intro lesson, saying `ImportError: cannot import name 'load_word_counts'`. 

I realized the python filenames must have changed at some point, from `wordcount.py` to `countwords.py`, but the import in `plotcounts.py` still used the old `wordcount`. I updated the name and the script worked fine.
