### PR TITLE
included install for debian linux

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -39,8 +39,9 @@ follow this lesson:
 
 #### Linux
 
-Make is a standard tool on Linux systems and should already be available.
+Make is a standard tool on most Linux systems and should already be available.
 Check if you already have Make installed by typing `make -v` into a terminal.
+In Debian linux, it is not a standard tool, and you should install from the terminal `sudo apt-get install make`.
 
 #### OSX
 


### PR DESCRIPTION
Make is not a standard tool in debian linux.

build-essential includes make. It is possible to install make instead of the complete build-essential for debian.

Reference to issue #143