### PR TITLE
Future-proof import of Sequence in plotcounts.py

### DIFF
--- a/code/plotcounts.py
+++ b/code/plotcounts.py
@@ -3,7 +3,10 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from countwords import load_word_counts
 


### PR DESCRIPTION
To keep the lesson working in Python >= 3.8, import `Sequence`
from `collections.abc` rather than from `collections`. For compatibility,
use try/except to import from `collections` in earlier versions of Python.

Avoids a deprecation warning when running through the lesson with Python 3.7.

For details on collections.abc vs collections, see [this Stack Overflow question](https://stackoverflow.com/q/55882715).

