### PR TITLE
Update guide.md with make/gmake remark

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -170,11 +170,12 @@ $ export LANGUAGE=en_US.UTF-8
 ~~~
 {: .bash}
 
+## Beware of different Make implementations!
+
+The lesson is based on GNU Make. Although it is very rare, on some systems (e.g. AIX) 
+you might find `make` not pointing to GNU Make and `gmake` needs to be used instead. 
+
 [graphviz]: http://www.graphviz.org/
 [lesson-example]: https://github.com/carpentries/lesson-example/
 [makefile2graph]: https://github.com/lindenb/makefile2graph
 [zipfile]: {{ page.root }}/files/make-lesson.zip
-
-## Beware of different Make implementations!
-
-The "Automation and Make" lesson is based on GNU Make. Although it is very rare, on some systems (e.g. AIX) you might find `make` not pointing to GNU Make and `gmake` needs to be used instead. 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -174,3 +174,7 @@ $ export LANGUAGE=en_US.UTF-8
 [lesson-example]: https://github.com/carpentries/lesson-example/
 [makefile2graph]: https://github.com/lindenb/makefile2graph
 [zipfile]: {{ page.root }}/files/make-lesson.zip
+
+## Beware of different Make implementations!
+
+The "Automation and Make" lesson is based on GNU Make. Although it is very rare, on some systems (e.g. AIX) you might find `make` not pointing to GNU Make and `gmake` needs to be used instead. 


### PR DESCRIPTION
It is very rare, but on some systems gmake needs to be used instead of make. 
This is a follow up change suggestion: https://github.com/swcarpentry/make-novice/issues/153 
