### PR TITLE
Reuse the case of different Makefile name to highlight the help funct…

### DIFF
--- a/_episodes/08-self-doc.md
+++ b/_episodes/08-self-doc.md
@@ -125,13 +125,13 @@ them for us.
 Our `help` target depends on our Makefile to be called `Makefile`. But
 what if our Makefile is renamed or we chose a different name to start
 with? Remember that if we call our Makefile something like 
-`MyOtherMakefile` we have to indicate it to `make`using the `-f` flag
+`MyOtherMakefile` we have to indicate it to `make` using the `-f` flag
 such as in `make -f MyOtherMakefile`. In case our Makefile has a 
 different name we could simply change the `help` dependency to `MyOtherMakefile`
 instead of `Makefile`. However `make` has a dedicated variable called `MAKEFILE_LIST` 
-which automatically includes the makefile name(s). Therefore, to enhance the 
-reusability of our code, we could change our `help` target to feature the 
-`MAKEFILE_LIST` variable:
+which automatically includes the makefile and configuration file(s) names.
+Therefore, to enhance the reusability of our code, we could change our `help`
+target to feature the `MAKEFILE_LIST` variable:
 
 ~~~
 .PHONY : help
@@ -140,7 +140,8 @@ help : $(MAKEFILE_LIST)
 ~~~
 {: .language-make}
 
-We can then obtain help by running
+Note that we would need to be careful not to use `##` for comments in our
+configuration files. We can then obtain help by running
 
 ~~~
 $ make -f MyOtherMakefile help

--- a/_episodes/08-self-doc.md
+++ b/_episodes/08-self-doc.md
@@ -95,7 +95,7 @@ help : Makefile
 ~~~
 {: .language-make}
 
-This rule depends upon the Makefile itself. It runs `sed` on the first
+This rule depends upon the Makefile itself, assumed to be named `Makefile`. It runs `sed` on the first
 dependency of the rule, which is our Makefile, and tells `sed` to get
 all the lines that begin with `##`, which `sed` then prints for us.
 
@@ -121,6 +121,31 @@ remember to add, update or remove a comment next to the rule. So long
 as we respect our convention of using `##` for such comments, then our
 `help` rule will take care of detecting these comments and printing
 them for us.
+
+Our `help` target depends on our Makefile to be called `Makefile`. But
+what if our Makefile is renamed or we chose a different name to start
+with? Remember that if we call our Makefile something like 
+`MyOtherMakefile` we have to indicate it to `make`using the `-f` flag
+such as in `make -f MyOtherMakefile`. In case our Makefile has a 
+different name we could simply change the `help` dependency to `MyOtherMakefile`
+instead of `Makefile`. However `make` has a dedicated variable called `MAKEFILE_LIST` 
+which automatically includes the makefile name(s). Therefore, to enhance the 
+reusability of our code, we could change our `help` target to feature the 
+`MAKEFILE_LIST` variable:
+
+~~~
+.PHONY : help
+help : $(MAKEFILE_LIST)
+	@sed -n 's/^##//p' $<
+~~~
+{: .language-make}
+
+We can then obtain help by running
+
+~~~
+$ make -f MyOtherMakefile help
+~~~
+{: .language-bash}
 
 > ## Where We Are
 >

--- a/code/09-conclusion-challenge-2/Makefile
+++ b/code/09-conclusion-challenge-2/Makefile
@@ -15,7 +15,7 @@ all : $(ZIPF_ARCHIVE)
 $(ZIPF_ARCHIVE) : $(ZIPF_DIR)
 	tar -czf $@ $<
 
-$(ZIPF_DIR): Makefile config.mk $(RESULTS_FILE) \
+$(ZIPF_DIR): $(MAKEFILE_LIST) $(RESULTS_FILE) \
              $(DAT_FILES) $(PNG_FILES) $(TXT_DIR) \
              $(COUNT_SRC) $(PLOT_SRC) $(ZIPF_SRC)
 	mkdir -p $@
@@ -52,6 +52,7 @@ clean :
 ## variables   : Print variables.
 .PHONY : variables
 variables:
+	@echo MAKEFILE_LIST: $(MAKEFILE_LIST)
 	@echo TXT_DIR: $(TXT_DIR)
 	@echo TXT_FILES: $(TXT_FILES)
 	@echo DAT_FILES: $(DAT_FILES)
@@ -60,5 +61,5 @@ variables:
 	@echo ZIPF_ARCHIVE: $(ZIPF_ARCHIVE)
 
 .PHONY : help
-help : Makefile
+help : $(MAKEFILE_LIST)
 	@sed -n 's/^##//p' $<


### PR DESCRIPTION
 The case of a makefile with a different name than `Makefile` is described in section `Makefiles`. However the `help` target described in the lesson explicitly depends on the name of the makefile in the code and assumes it is called `Makefile`. This PR reminds the student that the makefile can have any name, and provides a `help` dependency independent of the makefile name relying on the built-in `MAKEFILE_LIST` `make` variable.