### PR TITLE
Update the Gutenberg string

### DIFF
--- a/_episodes/07-functions.md
+++ b/_episodes/07-functions.md
@@ -277,7 +277,7 @@ now we have introduced our function:
 > choose a short name for the file (**that doesn't include spaces**) e.g. "dorian_gray.txt"
 > because the filename is going to be used in the `results.txt` file
 > * optionally, open the file in a text editor and remove extraneous text at the beginning and end
-> (look for the phrase `End of Project Gutenberg's [title], by [author]`)
+> (look for the phrase `END OF THE PROJECT GUTENBERG EBOOK [title]`)
 > * run `make` and check that the correct commands are run, given the dependency tree
 > * check the results.txt file to see how this book compares to the others
 {: .challenge}


### PR DESCRIPTION
Project Gutenberg seems to have changed the format of how they indicate the beginning and end of a text file. See e.g. the Picture of Dorian Gray example as suggested in the lesson. (Same holds for other books.)

(Thank you for a great tutorial!)
